### PR TITLE
fix: remove variable reference outside of velocity script blocks

### DIFF
--- a/oidc-provider/src/main/resources/templates/oidc/provider/userapplications.vm
+++ b/oidc-provider/src/main/resources/templates/oidc/provider/userapplications.vm
@@ -24,8 +24,6 @@
 #end
 {{/velocity}}
 
-$xcontext.userReference
-
 {{velocity}}
 #set ($discard = $xwiki.jsrx.use('templates/oidc/provider/userapplications.js'))
 #set ($obj = $doc.getObject("XWiki.XWikiUsers"))


### PR DESCRIPTION
remove variable reference outside of velocity script blocks to omit plaintext output in user profile application view